### PR TITLE
refatoração e correção para pegar as configurações padrões em settings.py

### DIFF
--- a/minio_spark/__init__.py
+++ b/minio_spark/__init__.py
@@ -31,7 +31,7 @@ class MinIOSpark:
         self._client = Minio(endpoint=conf.spark_hadoop_fs_s3a_endpoint,
                              access_key=conf.spark_hadoop_fs_s3a_access_key,
                              secret_key=conf.spark_hadoop_fs_s3a_secret_key,
-                             secure=conf.spark_hadoop_fs_s3a_connection_ssl_enabled)
+                             secure=conf.spark_hadoop_fs_s3a_connection_ssl_enabled=='true')
 
         if not isinstance(conf, ConfSparkS3):
             raise TypeError("self._conf_spark must be an instance of SparkConf")

--- a/minio_spark/settings.py
+++ b/minio_spark/settings.py
@@ -11,7 +11,7 @@ S3_BUCKET_CURATED_NAME = os.getenv('S3_BUCKET_CURATED_NAME', 'curated')
 S3_ENDPOINT = os.getenv('S3_ENDPOINT', 'minio:9000')  # Use the service name defined in docker-compose.yml
 S3_ACCESS_KEY = os.getenv('S3_ACCESS_KEY', 'minioadmin')
 S3_SECRET_KEY = os.getenv('S3_SECRET_KEY', 'minioadmin')
-S3_USE_SSL = False
+S3_USE_SSL = 'false'
 
 SPARK_CONF_S3_TEMPLATE.update({
     'spark.hadoop.fs.s3a.access.key': S3_ACCESS_KEY,

--- a/tests/test_spark_conf.py
+++ b/tests/test_spark_conf.py
@@ -1,0 +1,59 @@
+import logging
+import os
+import unittest
+import importlib
+from minio_spark.conf import SparkConfS3Kubernet
+from minio_spark import settings
+
+logger = logging.getLogger()
+class TestSparkConf(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        os.environ["SPARK_APP_NAME"] = "SparkAppName"
+
+        os.environ["S3_ENDPOINT"] = "minio-svc.minio.svc.cluster.local"
+        os.environ["S3_ACCESS_KEY"] = "user"
+        os.environ["S3_SECRET_KEY"] = "password"
+        os.environ["S3_USE_SSL"] = "false"
+
+        os.environ["SPARK_MASTER"] = "k8s://https://127.0.0.1:6443"
+        os.environ["SPARK_DRIVER_HOST"] = os.environ.get("MY_POD_IP", '127.0.0.1')
+        os.environ["SPARK_KUBERNETES_CONTAINER_IMAGE"] = "127.0.0.1:30800/pyspark-aws-psql:2.0"
+
+        # Reload the settings module to ensure all variables are read
+        importlib.reload(settings)
+
+
+    @classmethod
+    def tearDownClass(cls):
+        os.environ["SPARK_APP_NAME"] = "MinIOSpark"
+
+        os.environ["S3_ENDPOINT"] = "minio:9000"
+        os.environ["S3_ACCESS_KEY"] = "minioadmin"
+        os.environ["S3_SECRET_KEY"] = "minioadmin"
+        os.environ["S3_USE_SSL"] = "false"
+
+        os.environ["SPARK_MASTER"] = "k8s://https://host:port"
+        os.environ["SPARK_DRIVER_HOST"] = os.environ.get("MY_POD_IP", '127.0.0.1')
+        os.environ["SPARK_KUBERNETES_CONTAINER_IMAGE"] = "host:port/pyspark-aws-psql:2.0"
+
+        # Reload the settings module to ensure all variables are read
+        importlib.reload(settings)
+
+
+    def test_spark_conf(self):
+        conf = SparkConfS3Kubernet()
+
+        # Verifica se as configurações do Spark foram aplicadas corretamente
+        self.assertEqual(conf.get("spark.app.name"), "SparkAppName")
+        self.assertEqual(conf.get("spark.hadoop.fs.s3a.endpoint"), "minio-svc.minio.svc.cluster.local")
+        self.assertEqual(conf.get("spark.hadoop.fs.s3a.access.key"), "user")
+        self.assertEqual(conf.get("spark.hadoop.fs.s3a.secret.key"), "password")
+        self.assertEqual(conf.get("spark.hadoop.fs.s3a.connection.ssl.enabled"), "false")
+
+        self.assertEqual(conf.get("spark.master"), "k8s://https://127.0.0.1:6443")
+        self.assertEqual(conf.get("spark.driver.host"), os.environ.get("MY_POD_IP", '127.0.0.1'))
+        self.assertEqual(conf.get("spark.kubernetes.container.image"), "127.0.0.1:30800/pyspark-aws-psql:2.0")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refactor and Fix SSL Configuration in minio_spark

- Updated minio_spark/__init__.py to correctly handle SSL configuration by comparing 'secure' parameter to the string 'true'.
- Refactored minio_spark/conf.py:
  - Added a helper function _get_settings() to import settings dynamically.
  - Updated ConfSparkS3 class to use string type for s3_use_ssl instead of boolean.
  - Used default values from settings if parameters are not provided in the constructor of ConfSparkS3.
- Added new test file tests/test_spark_conf.py to ensure environment variables are loaded correctly and Spark configurations are properly applied.
