### PR TITLE
 Improve `extract_and_upload_zip` Method for Handling Large Files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def read(f):
 
 setup(
     name='minio_spark',
-    version='0.7.4',
+    version='0.7.5',
     description='An abstraction for working with DataLake using MinIO and PySpark.',
     long_description=read('README.md'),
     long_description_content_type='text/markdown',


### PR DESCRIPTION

- **Enhanced `extract_and_upload_zip` Method**:
  - Modified to process ZIP files in chunks to handle large files efficiently.
  - Utilizes streaming and chunked upload to avoid loading entire ZIP file into memory.
  - Added `part_size` parameter in `put_object` method to upload files in 10MB chunks.
  - Ensured proper resource management by closing the ZIP file and response object after processing.

- **Details of Changes**:
  - Instead of reading the entire ZIP file into memory, the method now reads and uploads each file within the ZIP in manageable chunks.
  - This approach minimizes memory usage, making the method suitable for processing very large ZIP files without risking memory overflow.

**Files Modified**:
  - `minio_spark/minio_spark.py`

These changes enhance the robustness and scalability of the `extract_and_upload_zip` method, enabling efficient handling of large ZIP files in memory-constrained environments.